### PR TITLE
Added finish-unfinish-error url (landing page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This is the official Veritrans extension for the OpenCart E-commerce platform.
 
   * **Payment Notification URL** in Settings to `http://[your shop's homepage]/index.php?route=payment/veritrans/payment_notification`
 
-  * **Finish Redirect URL** in Settings to `http://[your shop's homepage]/index.php?route=checkout/success&`
+  * **Finish Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
-  * **Error Redirect URL** in Settings to `http://[your shop's homepage]/index.php`
+  * **Error Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
-  * **Unfinish Redirect URL** in Settings to `http://[your shop's homepage]/index.php`
+  * **Unfinish Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
 rewrite by CBY

--- a/catalog/controller/payment/veritrans.php
+++ b/catalog/controller/payment/veritrans.php
@@ -322,7 +322,8 @@ class ControllerPaymentVeritrans extends Controller {
 
     }else if( isset($_GET['order_id']) && isset($_GET['transaction_status']) && $_GET['transaction_status'] == 'deny') {
       //if deny, redirect to order checkout page again
-      $redirUrl = $this->url->link('checkout/cart');
+      // $redirUrl = $this->url->link('checkout/cart');
+      $redirUrl = $this->url->link('payment/veritrans/failure','','SSL');
       $this->response->redirect($redirUrl);
 
     }else if( isset($_GET['order_id']) && !isset($_GET['transaction_status'])){ 
@@ -331,6 +332,32 @@ class ControllerPaymentVeritrans extends Controller {
       $this->response->redirect($redirUrl);
     }
     $this->response->redirect($redirUrl);
+  }
+  
+  /*
+  * redirect to payment failure using template & language (text template)
+  */
+  public function failure() {
+    $this->load->language('payment/veritrans');
+
+    $this->document->setTitle($this->language->get('heading_title'));
+
+    $data['heading_title'] = $this->language->get('heading_title');
+    $data['text_failure'] = $this->language->get('text_failure');
+
+    $data['column_left'] = $this->load->controller('common/column_left');
+    $data['column_right'] = $this->load->controller('common/column_right');
+    $data['content_top'] = $this->load->controller('common/content_top');
+    $data['content_bottom'] = $this->load->controller('common/content_bottom');
+    $data['footer'] = $this->load->controller('common/footer');
+    $data['header'] = $this->load->controller('common/header');
+    $data['checkout_url'] = $this->url->link('checkout/cart');
+
+    if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/veritrans_checkout_failure.tpl')) {
+      $this->response->setOutput($this->load->view($this->config->get('config_template') . '/template/payment/veritrans_checkout_failure.tpl', $data));
+    } else {
+      $this->response->setOutput($this->load->view('default/template/payment/veritrans_checkout_failure.tpl', $data));
+    }
   }
 
   /**

--- a/catalog/controller/payment/veritrans.php
+++ b/catalog/controller/payment/veritrans.php
@@ -306,6 +306,8 @@ class ControllerPaymentVeritrans extends Controller {
   /**
    * Landing page when payment is finished or failure or customer pressed "back" button
    * The Cart is cleared here, so make sure customer reach this page to ensure the cart is emptied when payment succeed
+   * Finish/unfinish/back url : 
+   * http://[your shop’s homepage]/opencart/index.php?route=payment/veritrans/payment_notification
    */
   public function landing_redir() {
     

--- a/catalog/controller/payment/veritrans.php
+++ b/catalog/controller/payment/veritrans.php
@@ -306,8 +306,8 @@ class ControllerPaymentVeritrans extends Controller {
   /**
    * Landing page when payment is finished or failure or customer pressed "back" button
    * The Cart is cleared here, so make sure customer reach this page to ensure the cart is emptied when payment succeed
-   * Finish/unfinish/back url : 
-   * http://[your shop’s homepage]/opencart/index.php?route=payment/veritrans/payment_notification
+   * payment finish/unfinish/error url : 
+   * http://[your shop’s homepage]/index.php?route=payment/veritrans/payment_notification
    */
   public function landing_redir() {
     

--- a/catalog/language/english/payment/veritrans.php
+++ b/catalog/language/english/payment/veritrans.php
@@ -1,13 +1,13 @@
 <?php
 // Text
 // Heading
-$_['heading_title']     = 'Thank you for shopping with %s .... ';
+$_['heading_title']     = 'Thank you for shopping with us ';
 
 // Text
 $_['text_title']        = 'Credit Card IDR Veritrans';
 $_['text_response']     = 'Response from Veritrans:';
 $_['text_success']      = '... your payment was successfully received.';
 $_['text_success_wait'] = '<b><span style="color: #FF0000">Please wait...</span></b> whilst we finish processing your order.<br>If you are not automatically re-directed in 10 seconds, please click <a href="%s">here</a>.';
-$_['text_failure']      = '... Your payment has been cancelled!';
+$_['text_failure']      = 'Sorry! Your payment has failed! Please do re-checkout or contact administrator/support ';
 $_['text_failure_wait'] = '<b><span style="color: #FF0000">Please wait...</span></b><br>If you are not automatically re-directed in 10 seconds, please click <a href="%s">here</a>.';
 ?>

--- a/catalog/view/theme/default/template/payment/veritrans_checkout_failure.tpl
+++ b/catalog/view/theme/default/template/payment/veritrans_checkout_failure.tpl
@@ -1,7 +1,12 @@
 <?php echo $header; ?><?php echo $column_left; ?><?php echo $column_right; ?>
-<div id="content"><?php echo $content_top; ?>
-  <h2><?php echo $heading_title; ?></h2>
-  <p><?php echo $text_payment_failed ?></p>
-  <?php echo $content_bottom; ?>
+<div class="container"><?php echo $content_top; ?>
+	<h2 class="text-center">Payment Failed!</h2>
+	<p class="text-center"><?php echo $text_failure ?></p>
+	<a href="<?php echo $checkout_url;?>">
+		<div class="text-center">
+			<button class="btn btn-primary">Re-Checkout!</button>
+		</div>
+	</a>
+	<?php echo $content_bottom; ?>
 </div>
 <?php echo $footer; ?>


### PR DESCRIPTION
- new `function landing_redir()` to handle redirection from VTWeb
- new `function failure()`, to handle failure payment
- relocated `cart->empty`, cart is emptied when customer reach payment success page after redirected from VTWeb
- locally tested, should be running as expected
## TODO
- update docs.veritrans.co.id for new finish-error-unfinish url which is :

`http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
